### PR TITLE
Replace deprecated experimental_rerun()

### DIFF
--- a/auth_functions.py
+++ b/auth_functions.py
@@ -80,7 +80,7 @@ def sign_in(email:str, password:str) -> None:
         # Save user info to session state and rerun
         else:
             st.session_state.user_info = user_info
-            st.experimental_rerun()
+            st.rerun()
 
     except requests.exceptions.HTTPError as error:
         error_message = json.loads(error.args[1])['error']['message']


### PR DESCRIPTION
experimental_rerun() removed from streamlit version 1.37, replaced with rerun()